### PR TITLE
Asset lookup registration rework

### DIFF
--- a/Src/IO/Asset.cs
+++ b/Src/IO/Asset.cs
@@ -132,12 +132,17 @@ namespace Dissonance.Engine.IO
 
 		private void SafelyWaitForLoad(Task loadTask, bool tracked)
 		{
-			if (State == AssetState.Loaded)
+			if (State == AssetState.Loaded) {
 				return;
+			}
 
 			if (!loadTask.IsCompleted && Assets.IsMainThread) {
-				while (Continuation == null) {
+				while (Continuation == null && State != AssetState.Loaded) {
 					Thread.Yield();
+				}
+
+				if (State == AssetState.Loaded) {
+					return;
 				}
 
 				if (tracked) {

--- a/Src/IO/Asset.cs
+++ b/Src/IO/Asset.cs
@@ -111,7 +111,7 @@ namespace Dissonance.Engine.IO
 			var asyncContext = new ContinuationScheduler(this);
 
 			string extension = Path.GetExtension(AssetPath);
-			var readerByExtension = Assets.ReadersByDataType<T>.ReaderByExtension;
+			var readerByExtension = Assets.AssetTypeData<T>.ReaderByExtension;
 
 			if (readerByExtension.Count == 0) {
 				throw new InvalidOperationException($"No asset reader found with a return type of '{typeof(T).Name}'.");

--- a/Src/IO/Asset.cs
+++ b/Src/IO/Asset.cs
@@ -20,8 +20,8 @@ namespace Dissonance.Engine.IO
 		/// <summary> The state of this asset. </summary>
 		public AssetState State { get; internal set; }
 
-		/// <summary> The source of this asset. Can be null. </summary>
-		public AssetSource Source { get; internal set; }
+		/// <summary> The file source of this asset. Can be null. </summary>
+		public AssetFileEntry? File { get; internal set; }
 
 		/// <summary> Whether or not this asset is currently being loaded. </summary>
 		public bool IsLoading => State == AssetState.Loading;
@@ -125,9 +125,7 @@ namespace Dissonance.Engine.IO
 				await Task.Yield(); // This transfers the method's execution to a worker thread.
 			}
 
-			using var stream = Source.OpenStream(AssetPath);
-
-			Value = await assetReader.ReadFromStream(stream, AssetPath, new MainThreadCreationContext(asyncContext));
+			Value = await assetReader.ReadAsset(File, new MainThreadCreationContext(asyncContext));
 
 			State = AssetState.Loaded;
 		}

--- a/Src/IO/AssetFileEntry.cs
+++ b/Src/IO/AssetFileEntry.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+
+namespace Dissonance.Engine.IO
+{
+	public class AssetFileEntry
+	{
+		public readonly string Path;
+		public readonly AssetSource Source;
+
+		public AssetFileEntry(string path, AssetSource source)
+		{
+			Path = path;
+			Source = source;
+		}
+
+		public Stream OpenStream()
+		{
+			return Source.OpenStream(Path);
+		}
+	}
+}

--- a/Src/IO/AssetLookup.cs
+++ b/Src/IO/AssetLookup.cs
@@ -26,7 +26,7 @@ namespace Dissonance.Engine.IO
 
 		public static void Register(string name, string path, Asset<T> asset)
 		{
-			if (lookup.ContainsKey(name)) {
+			if (lookup.TryGetValue(name, out var existingTuple) && existingTuple.assetPath == path) {
 				lookup[name] = (null, null); // This marks the registry as ambiguous.
 			} else {
 				lookup[name] = (path, asset);

--- a/Src/IO/Assets.cs
+++ b/Src/IO/Assets.cs
@@ -14,7 +14,6 @@ namespace Dissonance.Engine.IO
 		internal static class AssetTypeData<T>
 		{
 			public static readonly Dictionary<string, Asset<T>> Assets = new();
-			public static readonly HashSet<IAssetManager<T>> Managers = new();
 			public static readonly HashSet<IAssetReader<T>> Readers = new();
 			public static readonly Dictionary<string, IAssetReader<T>> ReaderByExtension = new();
 		}

--- a/Src/IO/Assets.cs
+++ b/Src/IO/Assets.cs
@@ -380,7 +380,9 @@ namespace Dissonance.Engine.IO
 				}
 
 				while (loadingAssets.TryDequeue(out var asset)) {
-					asset.Wait();
+					if (asset.State == AssetState.Loading) {
+						asset.Wait();
+					}
 				}
 			}
 		}

--- a/Src/IO/IAssetManager.cs
+++ b/Src/IO/IAssetManager.cs
@@ -1,9 +1,0 @@
-﻿using System.Threading.Tasks;
-
-namespace Dissonance.Engine.IO
-{
-	public interface IAssetManager<T>
-	{
-		ValueTask OnAssetAdded(Asset<T> asset);
-	}
-}

--- a/Src/IO/IAssetManager.cs
+++ b/Src/IO/IAssetManager.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Dissonance.Engine.IO
+{
+	public interface IAssetManager<T>
+	{
+		ValueTask OnAssetAdded(Asset<T> asset);
+	}
+}

--- a/Src/IO/IAssetReader.cs
+++ b/Src/IO/IAssetReader.cs
@@ -13,12 +13,6 @@ namespace Dissonance.Engine.IO
 		string[] Extensions { get; }
 
 		/// <summary>
-		/// Whether or not this asset reader should be ran for every fitting asset early on.
-		/// <br/> This is only evaluated when the reader is registered.
-		/// </summary>
-		bool AutoloadAssets => false;
-
-		/// <summary>
 		/// Reads the provided stream and returns a new instance of <typeparamref name="T"/> based on it and the provided <paramref name="assetPath"/>.
 		/// </summary>
 		/// <param name="stream"> The stream to read from. </param>

--- a/Src/IO/IAssetReader.cs
+++ b/Src/IO/IAssetReader.cs
@@ -13,12 +13,18 @@ namespace Dissonance.Engine.IO
 		string[] Extensions { get; }
 
 		/// <summary>
+		/// Whether or not this asset reader should be ran for every fitting asset early on.
+		/// <br/> This is only evaluated when the reader is registered.
+		/// </summary>
+		bool AutoloadAssets => false;
+
+		/// <summary>
 		/// Reads the provided stream and returns a new instance of <typeparamref name="T"/> based on it and the provided <paramref name="assetPath"/>.
 		/// </summary>
 		/// <param name="stream"> The stream to read from. </param>
 		/// <param name="assetPath"> The path of the asset that's currently being loaded. </param>
 		/// <param name="switchToMainThread"> Await this to switch execution of the method to the main thread. </param>
 		/// <returns> A result of type <see cref="T"/>. </returns>
-		ValueTask<T> ReadFromStream(Stream stream, string assetPath, MainThreadCreationContext switchToMainThread);
+		ValueTask<T> ReadAsset(AssetFileEntry assetFile, MainThreadCreationContext switchToMainThread);
 	}
 }

--- a/Src/IO/Readers/Audio/OggReader.cs
+++ b/Src/IO/Readers/Audio/OggReader.cs
@@ -9,18 +9,19 @@ namespace Dissonance.Engine.IO
 	{
 		public string[] Extensions { get; } = { ".ogg" };
 
-		public async ValueTask<AudioClip> ReadFromStream(Stream stream, string assetPath, MainThreadCreationContext switchToMainThread)
+		public async ValueTask<AudioClip> ReadAsset(AssetFileEntry assetFile, MainThreadCreationContext switchToMainThread)
 		{
-			using var r = new VorbisReader(stream, true);
+			using var stream = assetFile.OpenStream();
+			using var reader = new VorbisReader(stream, true);
 
-			long bufferSize = r.TotalSamples * r.Channels;
+			long bufferSize = reader.TotalSamples * reader.Channels;
 			float[] data = new float[bufferSize];
 
-			r.ReadSamples(data, 0, (int)bufferSize);
+			reader.ReadSamples(data, 0, (int)bufferSize);
 
 			var clip = new AudioClip();
 
-			clip.SetData(data, r.Channels, sizeof(float), r.SampleRate);
+			clip.SetData(data, reader.Channels, sizeof(float), reader.SampleRate);
 
 			return clip;
 		}

--- a/Src/IO/Readers/Audio/WavReader.cs
+++ b/Src/IO/Readers/Audio/WavReader.cs
@@ -9,8 +9,9 @@ namespace Dissonance.Engine.IO
 	{
 		public string[] Extensions { get; } = { ".wav" };
 
-		public async ValueTask<AudioClip> ReadFromStream(Stream stream, string assetPath, MainThreadCreationContext switchToMainThread)
+		public async ValueTask<AudioClip> ReadAsset(AssetFileEntry assetFile, MainThreadCreationContext switchToMainThread)
 		{
+			using var stream = assetFile.OpenStream();
 			using var reader = new BinaryReader(stream);
 
 			// RIFF header

--- a/Src/IO/Readers/BytesReader.cs
+++ b/Src/IO/Readers/BytesReader.cs
@@ -7,8 +7,10 @@ namespace Dissonance.Engine.IO
 	{
 		public string[] Extensions { get; } = { ".bytes" };
 
-		public async ValueTask<byte[]> ReadFromStream(Stream stream, string assetPath, MainThreadCreationContext switchToMainThread)
+		public async ValueTask<byte[]> ReadAsset(AssetFileEntry assetFile, MainThreadCreationContext switchToMainThread)
 		{
+			using var stream = assetFile.OpenStream();
+
 			byte[] bytes = new byte[stream.Length];
 
 			stream.Read(bytes, 0, bytes.Length);

--- a/Src/IO/Readers/Graphics/MaterialReader.cs
+++ b/Src/IO/Readers/Graphics/MaterialReader.cs
@@ -29,8 +29,9 @@ namespace Dissonance.Engine.IO
 
 		public string[] Extensions { get; } = { ".material" };
 
-		public async ValueTask<Material> ReadFromStream(Stream stream, string assetPath, MainThreadCreationContext switchToMainThread)
+		public async ValueTask<Material> ReadAsset(AssetFileEntry assetFile, MainThreadCreationContext switchToMainThread)
 		{
+			string assetPath = assetFile.Path;
 			string directory = Assets.FilterPath(Path.GetDirectoryName(assetPath));
 
 			var jsonMat = Assets.Get<JObject>(assetPath, AssetRequestMode.ImmediateLoad).Value.ToObject<JsonMaterial>();

--- a/Src/IO/Readers/Graphics/Models/GltfReader.cs
+++ b/Src/IO/Readers/Graphics/Models/GltfReader.cs
@@ -45,9 +45,12 @@ namespace Dissonance.Engine.IO
 
 		public string[] Extensions { get; } = { ".gltf", ".glb" };
 
-		public async ValueTask<PackedScene> ReadFromStream(Stream stream, string assetPath, MainThreadCreationContext switchToMainThread)
+		public async ValueTask<PackedScene> ReadAsset(AssetFileEntry assetFile, MainThreadCreationContext switchToMainThread)
 		{
+			string assetPath = assetFile.Path;
 			var info = new GltfInfo(assetPath);
+
+			using var stream = assetFile.OpenStream();
 
 			if (assetPath.EndsWith(".gltf")) {
 				byte[] textBytes = new byte[stream.Length - stream.Position];

--- a/Src/IO/Readers/Graphics/Models/ObjReader.cs
+++ b/Src/IO/Readers/Graphics/Models/ObjReader.cs
@@ -20,13 +20,13 @@ namespace Dissonance.Engine.IO
 
 		public string[] Extensions { get; } = { ".obj" };
 
-		public async ValueTask<Mesh> ReadFromStream(Stream stream, string assetPath, MainThreadCreationContext switchToMainThread)
+		public async ValueTask<Mesh> ReadAsset(AssetFileEntry assetFile, MainThreadCreationContext switchToMainThread)
 		{
-			string text;
+			using var stream = assetFile.OpenStream();
+			using var reader = new StreamReader(stream);
 
-			using (var reader = new StreamReader(stream)) {
-				text = reader.ReadToEnd();
-			}
+			string assetPath = assetFile.Path;
+			string text = reader.ReadToEnd();
 
 			float scale = 1f;
 			var meshInfo = CreateOBJInfo(text);

--- a/Src/IO/Readers/Graphics/ShaderReader.cs
+++ b/Src/IO/Readers/Graphics/ShaderReader.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Dissonance.Engine.Graphics;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Dissonance.Engine.IO
@@ -13,9 +12,12 @@ namespace Dissonance.Engine.IO
 
 		public bool AutoloadAssets => !Game.Instance.Flags.HasFlag(GameFlags.NoGraphics);
 
-		public async ValueTask<Asset<Shader>[]> ReadFromStream(Stream stream, string assetPath, MainThreadCreationContext switchToMainThread)
+		public async ValueTask<Asset<Shader>[]> ReadAsset(AssetFileEntry assetFile, MainThreadCreationContext switchToMainThread)
 		{
+			string assetPath = assetFile.Path;
 			string directory = Assets.FilterPath(Path.GetDirectoryName(assetPath));
+
+			using var stream = assetFile.OpenStream();
 			using var reader = new StreamReader(stream);
 
 			string jsonText = reader.ReadToEnd();

--- a/Src/IO/Readers/HjsonReader.cs
+++ b/Src/IO/Readers/HjsonReader.cs
@@ -11,8 +11,9 @@ namespace Dissonance.Engine.IO
 		public string[] Extensions { get; } = new[] { "*", ".hjson" };
 
 		// Newtonsoft.Json
-		async ValueTask<JObject> IAssetReader<JObject>.ReadFromStream(Stream stream, string assetPath, MainThreadCreationContext switchToMainThread)
+		async ValueTask<JObject> IAssetReader<JObject>.ReadAsset(AssetFileEntry assetFile, MainThreadCreationContext switchToMainThread)
 		{
+			string assetPath = assetFile.Path;
 			string hjsonText = Assets.Get<string>(assetPath, AssetRequestMode.ImmediateLoad).Value;
 			using var hjsonReader = new StringReader(hjsonText);
 
@@ -23,8 +24,9 @@ namespace Dissonance.Engine.IO
 		}
 
 		// System.Text.Json
-		async ValueTask<JsonDocument> IAssetReader<JsonDocument>.ReadFromStream(Stream stream, string assetPath, MainThreadCreationContext switchToMainThread)
+		async ValueTask<JsonDocument> IAssetReader<JsonDocument>.ReadAsset(AssetFileEntry assetFile, MainThreadCreationContext switchToMainThread)
 		{
+			string assetPath = assetFile.Path;
 			string hjsonText = Assets.Get<string>(assetPath, AssetRequestMode.ImmediateLoad).Value;
 			using var hjsonReader = new StringReader(hjsonText);
 

--- a/Src/IO/Readers/Physics/ConvexCollisionMeshManager.cs
+++ b/Src/IO/Readers/Physics/ConvexCollisionMeshManager.cs
@@ -1,8 +1,6 @@
+using System.Threading.Tasks;
 using Dissonance.Engine.Graphics;
 using Dissonance.Engine.Physics;
-using System;
-using System.IO;
-using System.Threading.Tasks;
 
 namespace Dissonance.Engine.IO
 {
@@ -10,8 +8,9 @@ namespace Dissonance.Engine.IO
 	{
 		public string[] Extensions { get; } = { ".obj" };
 
-		public async ValueTask<ConvexCollisionMesh> ReadFromStream(Stream stream, string assetPath, MainThreadCreationContext switchToMainThread)
+		public async ValueTask<ConvexCollisionMesh> ReadAsset(AssetFileEntry assetFile, MainThreadCreationContext switchToMainThread)
 		{
+			string assetPath = assetFile.Path;
 			var mesh = Assets.Get<Mesh>(assetPath, AssetRequestMode.ImmediateLoad).Value;
 			var collisionMesh = new ConvexCollisionMesh();
 

--- a/Src/IO/Readers/TextReader.cs
+++ b/Src/IO/Readers/TextReader.cs
@@ -7,8 +7,9 @@ namespace Dissonance.Engine.IO
 	{
 		public string[] Extensions { get; } = { "*", ".txt" };
 
-		public async ValueTask<string> ReadFromStream(Stream stream, string assetPath, MainThreadCreationContext switchToMainThread)
+		public async ValueTask<string> ReadAsset(AssetFileEntry assetFile, MainThreadCreationContext switchToMainThread)
 		{
+			using var stream = assetFile.OpenStream();
 			using var reader = new StreamReader(stream);
 
 			return reader.ReadToEnd();

--- a/Src/IO/Readers/Textures/PngReader.cs
+++ b/Src/IO/Readers/Textures/PngReader.cs
@@ -12,8 +12,10 @@ namespace Dissonance.Engine.IO
 	{
 		public string[] Extensions { get; } = { ".png" };
 
-		public async ValueTask<Texture> ReadFromStream(Stream stream, string assetPath, MainThreadCreationContext switchToMainThread)
+		public async ValueTask<Texture> ReadAsset(AssetFileEntry assetFile, MainThreadCreationContext switchToMainThread)
 		{
+			using var stream = assetFile.OpenStream();
+
 			var (width, height, pixels) = LoadImageData<Rgba32>(stream);
 
 			await switchToMainThread; // Switches context to the main thread for texture uploading.


### PR DESCRIPTION
Continuation of #11. In short, this branch does the following:
- Readjusts AssetLookup registrations to happen without relation to asset loading.
- Content sources are no longer accessed after initialization, at which asset file lists are now built.
- IAssetReader's read method now has its `stream` & `assetPath` AssetFileEntry parameters replaced with `AssetFileEntry`, which has an OpenStream method and a Path field. This allows readers to create data from elsewhere, if needed.